### PR TITLE
add ability for multiple secrets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
           go-version: '^1.13.1'
       - name: install dependencies
         run: |
-          apt-get update -y
-          apt-get install -y gcc git
+          sudo apt-get update -y
+          sudo apt-get install -y gcc git
       - name: test
         run: cd cmd/aws-secrets-manager && go test -v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: validate
+
+on:
+  push:
+    branches:
+    - '*'
+    - '!master'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1'
+      - name: install dependencies
+        run: |
+          apt-get update -y
+          apt-get install -y gcc git
+      - name: test
+        run: cd cmd/aws-secrets-manager && go test -v

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 The _aws-secret-sidecar-injector_ is a proof-of-concept(PoC) that allows your containerized applications to consume secrets from AWS Secrets Manager. The solution makes use of a Kubernetes dynamic admission controller that injects an _init_ container, aws-secrets-manager-secret-sidecar, upon creation/update of your pod. The init container relies on [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to retrieve the secret from AWS Secrets Manager. The Kubernetes dynamic admission controller also creates an in-memory Kubernetes volume (with name `secret-vol` and `emptyDirectory.medium` as `Memory`) associated with the pod to access the secret.
 
-## Prerequsites 
+## Prerequsites
 - An IRSA ServiceAccount that has permission to access and retrive the secret from AWS Secrets Manager
 - Helm to install the mutating admission webhook
 
 ## Installation
 
-### Deploying mutatating webhook to inject the init container 
+### Deploying mutatating webhook to inject the init container
 
-- Add the Helm repository which contains the Helm chart for the mutating admission webhook 
+- Add the Helm repository which contains the Helm chart for the mutating admission webhook
 
   ```helm repo add secret-inject https://aws-samples.github.io/aws-secret-sidecar-injector/```
 
-- Update the Helm repository 
+- Update the Helm repository
 
   ```helm repo update```
 
@@ -24,15 +24,15 @@ The _aws-secret-sidecar-injector_ is a proof-of-concept(PoC) that allows your co
 
 ## Accessing the secret
 
-Add the following annotations to your podSpec to mount the secret in your pod 
+Add the following annotations to your podSpec to mount the secret in your pod
 
   ```secrets.k8s.aws/sidecarInjectorWebhook: enabled```
 
   ```secrets.k8s.aws/secret-arn: <SECRET-ARN>```
-  
-The decrypted secret is written to a volume named `secret-vol` and the filename of the secret is `secret`. The Kubernetes dynamic admission controller also creates corresponding mountPath `/tmp/secret` for containers within the pod to access the secret. 
 
-This repository contains a sample Kubernetes deployment [manifest](https://github.com/aws-samples/aws-secret-sidecar-injector/blob/master/kubernetes-manifests/webserver.yaml) which uses this project to access AWS Secrets Manager secret.  
+The decrypted secret is written to a volume named `secret-vol` and the filename of the secret is the name within secrets manager. The Kubernetes dynamic admission controller also creates corresponding mountPath `/tmp/secrets` for containers within the pod to access the secret.
+
+This repository contains a sample Kubernetes deployment [manifest](https://github.com/aws-samples/aws-secret-sidecar-injector/blob/master/kubernetes-manifests/webserver.yaml) which uses this project to access AWS Secrets Manager secret.
 
 ## Creating Secrets
 

--- a/cmd/aws-secrets-manager/main_test.go
+++ b/cmd/aws-secrets-manager/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	aws "github.com/aws/aws-sdk-go/aws"
+	secretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
+	secretsmanageriface "github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+)
+
+type mockSecretsManagerClient struct {
+	secretsmanageriface.SecretsManagerAPI
+}
+
+func (m *mockSecretsManagerClient) GetSecretValue(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	return &secretsmanager.GetSecretValueOutput{
+		ARN:          aws.String("aws:foo"),
+		SecretString: aws.String("some-value"),
+	}, nil
+}
+
+func TestGetSecretValue(t *testing.T) {
+	mockSvc := &mockSecretsManagerClient{}
+
+	response := getSecretValue(mockSvc, "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-password-hlRvvF")
+	if response != "some-value" {
+		t.Errorf("Vale was incorrect, got: %s, want: value.", response)
+	}
+}

--- a/kubernetes-manifests/sa.yaml
+++ b/kubernetes-manifests/sa.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/webserver-role
+  labels:
+    run: webserver
+  name: webserver-service-account

--- a/kubernetes-manifests/webserver.yaml
+++ b/kubernetes-manifests/webserver.yaml
@@ -22,4 +22,4 @@ spec:
       containers:
       - image: busybox:1.28
         name: webserver
-        command: ['sh', '-c', 'echo $(cat /tmp/secret) && sleep 3600']
+        command: ['sh', '-c', 'echo $(ls /tmp/secrets) && sleep 3600']


### PR DESCRIPTION
*Issue #, if available:* closes #13 

*Description of changes:*

- Changed the secret path to mount at `/tmp/secrets/<secret name>`
- Added test for aws-secrets-manager


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
