### PR TITLE
Rely on .Release.Namespace for tls cert domain

### DIFF
--- a/admission-controller/secret-inject/templates/_helpers.tpl
+++ b/admission-controller/secret-inject/templates/_helpers.tpl
@@ -12,7 +12,7 @@ Generate certificates for AWS Secrets Controller webhook
 {{- define "secret-inject.gen-certs" -}}
 {{- $altNames := "secret-inject.default.svc" -}}
 {{- $ca := genCA "secret-inject-ca" 3650 -}}
-{{- $cert := genSignedCert "secret-inject.default.svc" nil nil  3650 $ca -}}
+{{- $cert := genSignedCert (printf "secret-inject.%s.svc" .Release.Namespace) nil nil  3650 $ca -}}
 caCert: {{ $ca.Cert | b64enc }}
 clientCert: {{ $cert.Cert | b64enc }}
 clientKey: {{ $cert.Key | b64enc }}


### PR DESCRIPTION
Use `.Release.Namespace` in domain passed to helm genSignedCert helper.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
