### PR TITLE
Annotations

### DIFF
--- a/admission-controller/pods.go
+++ b/admission-controller/pods.go
@@ -82,10 +82,6 @@ func admitPods(ar v1.AdmissionReview) *v1.AdmissionResponse {
 
 func mutatePods(ar v1.AdmissionReview) *v1.AdmissionResponse {
 	shouldPatchPod := func(pod *corev1.Pod) bool {
-               inject_status, _ :=  pod.ObjectMeta.Annotations["secrets.k8s.aws/sidecarInjectorWebhook"]
-               if inject_status != "enabled" {
-                   return false
-               }
                _, arn_ok :=  pod.ObjectMeta.Annotations["secrets.k8s.aws/secret-arn"]
                if arn_ok == false {
                   return false

--- a/kubernetes-manifests/webserver.yaml
+++ b/kubernetes-manifests/webserver.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       annotations:
-        secrets.k8s.aws/sidecarInjectorWebhook: enabled
         secrets.k8s.aws/secret-arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:database-password-hlRvvF
       labels:
         run: webserver


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the annotation secrets.k8s.aws/sidecarInjectorWebhook. 
The sidecar is injected if secrets.k8s.aws/secret-arn is specified, if this annotation is not specified the sidecar is not injected. This change doesnt break existing use sidecarinjectirWebhook annotation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
